### PR TITLE
Update README.md with proper installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ function names_. This hinders debugging and confuses automatic crash stack conso
 
 ## Installation
 
+Note: We have not yet published this package to npmjs.org, so for now you can install directly from the repository.
+
 ```bash
-npm install @bloomberg/pasta-sourcemaps
+npm install https://github.com/bloomberg/pasta-sourcemaps
 ```
 
 ## API


### PR DESCRIPTION
Since the package has not been published to npmjs.org yet, users
must install directly from the repository.

Signed-off-by: Kevin P. Fleming <kpfleming@bloomberg.net>