### PR TITLE
Correct Travis CI link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/bloomberg/pasta-sourcemaps.svg?branch=master)](https://travis-ci.org/bloomberg/pasta-sourcemaps)
+[![Build Status](https://travis-ci.com/bloomberg/pasta-sourcemaps.svg?branch=master)](https://travis-ci.com/bloomberg/pasta-sourcemaps)
 
 # pasta-sourcemaps
 


### PR DESCRIPTION
The correct Travis CI link is https://travis-ci.com/bloomberg/pasta-sourcemaps, 
update in README.