### PR TITLE
Remove extra build from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - "node"
 script: 
   - npm run lint
-  - npm run build
   - npm run test
 branches:
   only:


### PR DESCRIPTION
`npm ci` already runs `npm run prepare` which in turn runs `npm run
build`. This means we don't need to explicitly build in the Travis
config.

Signed-off-by: Thomas Chetwin <tchetwin@bloomberg.net>