### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,8 @@ function names_. This hinders debugging and confuses automatic crash stack conso
 
 ## Installation
 
-Note: We have not yet published this package to npmjs.org, so for now you can install directly from the repository.
-
 ```bash
-npm install https://github.com/bloomberg/pasta-sourcemaps
+npm install @bloomberg/pasta-sourcemaps
 ```
 
 ## API

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomberg/pasta-sourcemaps",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomberg/pasta-sourcemaps",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pretty (and) Accurate Stack Trace Analysis",
   "main": "./dist/src/main.js",
   "types": "./dist/src/main.d.ts",


### PR DESCRIPTION
The package is now available on npm therefore it can be installed
with `npm install @bloomberg/pasta-sourcemaps`.

Signed-off-by: Lilit Darbinyan <ldarbinyan@bloomberg.net>