### PR TITLE
Prefix function name with class and object literal names

### DIFF
--- a/tests/fixtures/parser/arrow.js.function_descs.json
+++ b/tests/fixtures/parser/arrow.js.function_descs.json
@@ -42,7 +42,7 @@
         "endColumn": 1
     },
     {
-        "name": "f4",
+        "name": "obj.f4",
         "startLine": 19,
         "startColumn": 7,
         "endLine": 21,

--- a/tests/fixtures/parser/async.js.function_descs.json
+++ b/tests/fixtures/parser/async.js.function_descs.json
@@ -21,7 +21,7 @@
         "endColumn": 1
     },
     {
-        "name": "f3",
+        "name": "obj.f3",
         "startLine": 10,
         "startColumn": 11,
         "endLine": 14,

--- a/tests/fixtures/parser/class.js
+++ b/tests/fixtures/parser/class.js
@@ -1,5 +1,6 @@
-let prop1 = "prop value";
-let prop2 = "prop value";
+let prop1 = "prop value 1";
+let prop2 = "prop value 2 ";
+let prop3 = "prop value 3";
 let sym = new Symbol();
 class A
 {
@@ -51,6 +52,10 @@ class A
         //..
     }
 
+    static [prop3]() {
+        //..
+    }
+
     "stringLiteral" () {
         //..
     }
@@ -59,7 +64,7 @@ class A
         //..
     }
 
-    43() {
+    static "stringLiteral2" () {
         //..
     }
 
@@ -71,6 +76,18 @@ class A
         //..
     }
 
+    static ["def"]() {
+        //..
+    }
+
+    43() {
+        //..
+    }
+
+    static 42() {
+        //..
+    }
+
     [44]() {
         //..
     }
@@ -79,7 +96,15 @@ class A
         //..
     }
 
+    static [46]() {
+        //..
+    }
+
     ["a"+"b"]() {
+        //..
+    }
+
+    static ["d"+"e"]() {
         //..
     }
 

--- a/tests/fixtures/parser/class.js.function_descs.json
+++ b/tests/fixtures/parser/class.js.function_descs.json
@@ -3,168 +3,210 @@
         "name": "<top-level>",
         "startLine": 0,
         "startColumn": 0,
-        "endLine": 92,
+        "endLine": 117,
         "endColumn": 1
     },
     {
         "name": "A",
-        "startLine": 4,
+        "startLine": 5,
         "startColumn": 1,
-        "endLine": 8,
+        "endLine": 9,
         "endColumn": 5
     },
     {
-        "name": "f1",
-        "startLine": 8,
+        "name": "A.prototype.f1",
+        "startLine": 9,
         "startColumn": 5,
-        "endLine": 12,
+        "endLine": 13,
         "endColumn": 5
     },
     {
-        "name": "f2",
-        "startLine": 12,
+        "name": "A.f2",
+        "startLine": 13,
         "startColumn": 5,
-        "endLine": 16,
+        "endLine": 17,
         "endColumn": 5
     },
     {
-        "name": "get z",
-        "startLine": 16,
+        "name": "A.prototype.get z",
+        "startLine": 17,
         "startColumn": 5,
-        "endLine": 20,
+        "endLine": 21,
         "endColumn": 5
     },
     {
-        "name": "set z",
-        "startLine": 20,
+        "name": "A.prototype.set z",
+        "startLine": 21,
         "startColumn": 5,
-        "endLine": 23,
+        "endLine": 24,
         "endColumn": 5
     },
     {
-        "name": "get Z",
-        "startLine": 23,
+        "name": "A.get Z",
+        "startLine": 24,
         "startColumn": 5,
-        "endLine": 27,
+        "endLine": 28,
         "endColumn": 5
     },
     {
-        "name": "f3",
-        "startLine": 27,
+        "name": "A.prototype.f3",
+        "startLine": 28,
         "startColumn": 5,
-        "endLine": 31,
+        "endLine": 32,
         "endColumn": 5
     },
     {
-        "name": "f4",
-        "startLine": 31,
+        "name": "A.f4",
+        "startLine": 32,
         "startColumn": 5,
-        "endLine": 35,
+        "endLine": 36,
         "endColumn": 5
     },
     {
-        "name": "f5",
-        "startLine": 35,
+        "name": "A.prototype.f5",
+        "startLine": 36,
         "startColumn": 5,
-        "endLine": 39,
+        "endLine": 40,
         "endColumn": 5
     },
     {
-        "name": "f6",
-        "startLine": 39,
+        "name": "A.f6",
+        "startLine": 40,
         "startColumn": 5,
-        "endLine": 43,
+        "endLine": 44,
         "endColumn": 5
     },
     {
-        "name": "<computed: prop1>",
-        "startLine": 43,
+        "name": "A.prototype.<computed: prop1>",
+        "startLine": 44,
         "startColumn": 5,
-        "endLine": 47,
+        "endLine": 48,
         "endColumn": 5
     },
     {
-        "name": "<computed: prop2>",
-        "startLine": 47,
+        "name": "A.prototype.<computed: prop2>",
+        "startLine": 48,
         "startColumn": 5,
-        "endLine": 51,
+        "endLine": 52,
         "endColumn": 5
     },
     {
-        "name": "stringLiteral",
-        "startLine": 51,
+        "name": "A.<computed: prop3>",
+        "startLine": 52,
         "startColumn": 5,
-        "endLine": 55,
+        "endLine": 56,
         "endColumn": 5
     },
     {
-        "name": " string Literal ",
-        "startLine": 55,
+        "name": "A.prototype.stringLiteral",
+        "startLine": 56,
         "startColumn": 5,
-        "endLine": 59,
+        "endLine": 60,
         "endColumn": 5
     },
     {
-        "name": "43",
-        "startLine": 59,
+        "name": "A.prototype. string Literal ",
+        "startLine": 60,
         "startColumn": 5,
-        "endLine": 63,
+        "endLine": 64,
         "endColumn": 5
     },
     {
-        "name": "abc",
-        "startLine": 63,
+        "name": "A.stringLiteral2",
+        "startLine": 64,
         "startColumn": 5,
-        "endLine": 67,
+        "endLine": 68,
         "endColumn": 5
     },
     {
-        "name": " a b c ",
-        "startLine": 67,
+        "name": "A.prototype.abc",
+        "startLine": 68,
         "startColumn": 5,
-        "endLine": 71,
+        "endLine": 72,
         "endColumn": 5
     },
     {
-        "name": "44",
-        "startLine": 71,
+        "name": "A.prototype. a b c ",
+        "startLine": 72,
         "startColumn": 5,
-        "endLine": 75,
+        "endLine": 76,
         "endColumn": 5
     },
     {
-        "name": "45",
-        "startLine": 75,
+        "name": "A.def",
+        "startLine": 76,
         "startColumn": 5,
-        "endLine": 79,
+        "endLine": 80,
         "endColumn": 5
     },
     {
-        "name": "<computed>",
-        "startLine": 79,
+        "name": "A.prototype.43",
+        "startLine": 80,
         "startColumn": 5,
-        "endLine": 83,
+        "endLine": 84,
         "endColumn": 5
     },
     {
-        "name": "<computed: sym>",
-        "startLine": 83,
+        "name": "A.42",
+        "startLine": 84,
         "startColumn": 5,
-        "endLine": 87,
+        "endLine": 88,
         "endColumn": 5
     },
     {
-        "name": "<computed>",
-        "startLine": 87,
+        "name": "A.prototype.44",
+        "startLine": 88,
         "startColumn": 5,
-        "endLine": 91,
+        "endLine": 92,
+        "endColumn": 5
+    },
+    {
+        "name": "A.prototype.45",
+        "startLine": 92,
+        "startColumn": 5,
+        "endLine": 96,
+        "endColumn": 5
+    },
+    {
+        "name": "A.46",
+        "startLine": 96,
+        "startColumn": 5,
+        "endLine": 100,
+        "endColumn": 5
+    },
+    {
+        "name": "A.prototype.<computed>",
+        "startLine": 100,
+        "startColumn": 5,
+        "endLine": 104,
+        "endColumn": 5
+    },
+    {
+        "name": "A.<computed>",
+        "startLine": 104,
+        "startColumn": 5,
+        "endLine": 108,
+        "endColumn": 5
+    },
+    {
+        "name": "A.prototype.<computed: sym>",
+        "startLine": 108,
+        "startColumn": 5,
+        "endLine": 112,
+        "endColumn": 5
+    },
+    {
+        "name": "A.prototype.<computed>",
+        "startLine": 112,
+        "startColumn": 5,
+        "endLine": 116,
         "endColumn": 5
     },
     {
         "name": "<anonymous>",
-        "startLine": 89,
+        "startLine": 114,
         "startColumn": 6,
-        "endLine": 89,
+        "endLine": 114,
         "endColumn": 18
     }
 ]

--- a/tests/fixtures/parser/class.ts
+++ b/tests/fixtures/parser/class.ts
@@ -1,4 +1,6 @@
 let prop1 = "prop1";
+let prop2 = "prop2";
+let prop3 = "prop3";
 let sym1 = Symbol();
 class D
 {
@@ -17,11 +19,18 @@ class D
     };
 
     protected f3 = function localName() {
-
         //..
     };
 
     static f4() {
+        //..
+    }
+
+    private static f5 = function() {
+        //..
+    };
+
+    public static f6 = function localName() {
         //..
     }
 
@@ -38,27 +47,35 @@ class D
         //..   
     }
 
-    public *f5() {
+    public *f7() {
         //..
     }
 
-    static *f6() {
+    static *f8() {
         //..
     }
 
-    private async f7() {
+    private async f9() {
         //..
     }
 
-    static async f8() {
+    static async f10() {
         //..
     }
 
-    protected f9 = () => {
+    protected f11 = () => {
+        //..
+    };
+
+    static f12 = () => {
         //..
     };
 
     [prop1]() {
+        //..
+    }
+
+    static [prop2]() {
         //..
     }
 
@@ -71,7 +88,23 @@ class D
         //..
     };
 
+    static "stringLiteral3" () {
+        //..
+    }
+
+    static "stringLiteral4" = function() {
+        //..
+    };
+
     ["abc"]() {
+        //..
+    }
+
+    static ["def"]() {
+        //..
+    }
+
+    static ["xyz"] = function() {
         //..
     }
 
@@ -88,13 +121,31 @@ class D
         //..
     }
 
+    static 45() {
+        //..
+    }
+
+    static [46]() {
+        //..
+    }
+
+    static 47 = function() {
+        //..
+    };
+
+    static [48] = function() {
+        //..
+    };
+
     ["a"+"b"]() {
+        //..
+    }
+
+    static ["c"+"d"]() {
         //..
     }
 
     [sym1]() {
         //..
     }
-
-
 }

--- a/tests/fixtures/parser/class.ts.function_descs.json
+++ b/tests/fixtures/parser/class.ts.function_descs.json
@@ -3,161 +3,252 @@
         "name": "<top-level>",
         "startLine": 0,
         "startColumn": 0,
-        "endLine": 99,
+        "endLine": 150,
         "endColumn": 1
     },
     {
         "name": "D",
-        "startLine": 3,
+        "startLine": 5,
         "startColumn": 1,
-        "endLine": 7,
+        "endLine": 9,
         "endColumn": 5
     },
     {
-        "name": "f1",
-        "startLine": 7,
+        "name": "D.prototype.f1",
+        "startLine": 9,
         "startColumn": 5,
-        "endLine": 11,
+        "endLine": 13,
         "endColumn": 5
     },
     {
         "name": "f2",
-        "startLine": 13,
+        "startLine": 15,
         "startColumn": 16,
-        "endLine": 16,
+        "endLine": 18,
         "endColumn": 5
     },
     {
         "name": "localName",
-        "startLine": 18,
+        "startLine": 20,
         "startColumn": 18,
-        "endLine": 21,
+        "endLine": 22,
         "endColumn": 5
     },
     {
-        "name": "f4",
-        "startLine": 21,
+        "name": "D.f4",
+        "startLine": 22,
         "startColumn": 6,
-        "endLine": 25,
+        "endLine": 26,
         "endColumn": 5
     },
     {
-        "name": "get z",
-        "startLine": 25,
-        "startColumn": 5,
+        "name": "D.f5",
+        "startLine": 28,
+        "startColumn": 23,
         "endLine": 30,
         "endColumn": 5
     },
     {
-        "name": "set z",
-        "startLine": 30,
-        "startColumn": 5,
-        "endLine": 33,
+        "name": "localName",
+        "startLine": 32,
+        "startColumn": 22,
+        "endLine": 34,
         "endColumn": 5
     },
     {
-        "name": "get Z",
-        "startLine": 33,
+        "name": "D.prototype.get z",
+        "startLine": 34,
         "startColumn": 5,
-        "endLine": 38,
+        "endLine": 39,
         "endColumn": 5
     },
     {
-        "name": "f5",
-        "startLine": 38,
+        "name": "D.prototype.set z",
+        "startLine": 39,
         "startColumn": 5,
         "endLine": 42,
         "endColumn": 5
     },
     {
-        "name": "f6",
+        "name": "D.get Z",
         "startLine": 42,
         "startColumn": 5,
-        "endLine": 46,
+        "endLine": 47,
         "endColumn": 5
     },
     {
-        "name": "f7",
-        "startLine": 46,
+        "name": "D.prototype.f7",
+        "startLine": 47,
         "startColumn": 5,
-        "endLine": 50,
+        "endLine": 51,
         "endColumn": 5
     },
     {
-        "name": "f8",
-        "startLine": 50,
+        "name": "D.f8",
+        "startLine": 51,
         "startColumn": 5,
-        "endLine": 54,
+        "endLine": 55,
         "endColumn": 5
     },
     {
-        "name": "f9",
-        "startLine": 56,
-        "startColumn": 18,
-        "endLine": 58,
-        "endColumn": 5
-    },
-    {
-        "name": "<computed: prop1>",
-        "startLine": 58,
-        "startColumn": 6,
-        "endLine": 62,
-        "endColumn": 5
-    },
-    {
-        "name": "stringLiteral1",
-        "startLine": 62,
+        "name": "D.prototype.f9",
+        "startLine": 55,
         "startColumn": 5,
-        "endLine": 66,
+        "endLine": 59,
         "endColumn": 5
     },
     {
-        "name": "stringLiteral2",
-        "startLine": 68,
-        "startColumn": 22,
+        "name": "D.f10",
+        "startLine": 59,
+        "startColumn": 5,
+        "endLine": 63,
+        "endColumn": 5
+    },
+    {
+        "name": "f11",
+        "startLine": 65,
+        "startColumn": 19,
+        "endLine": 67,
+        "endColumn": 5
+    },
+    {
+        "name": "D.f12",
+        "startLine": 69,
+        "startColumn": 16,
         "endLine": 71,
         "endColumn": 5
     },
     {
-        "name": "abc",
+        "name": "D.prototype.<computed: prop1>",
         "startLine": 71,
         "startColumn": 6,
         "endLine": 75,
         "endColumn": 5
     },
     {
-        "name": "42",
-        "startLine": 77,
-        "startColumn": 8,
-        "endLine": 80,
-        "endColumn": 5
-    },
-    {
-        "name": "43",
-        "startLine": 80,
-        "startColumn": 6,
-        "endLine": 84,
-        "endColumn": 5
-    },
-    {
-        "name": "44",
-        "startLine": 84,
+        "name": "D.<computed: prop2>",
+        "startLine": 75,
         "startColumn": 5,
+        "endLine": 79,
+        "endColumn": 5
+    },
+    {
+        "name": "D.prototype.stringLiteral1",
+        "startLine": 79,
+        "startColumn": 5,
+        "endLine": 83,
+        "endColumn": 5
+    },
+    {
+        "name": "stringLiteral2",
+        "startLine": 85,
+        "startColumn": 22,
         "endLine": 88,
         "endColumn": 5
     },
     {
-        "name": "<computed>",
+        "name": "D.stringLiteral3",
         "startLine": 88,
-        "startColumn": 5,
+        "startColumn": 6,
         "endLine": 92,
         "endColumn": 5
     },
     {
-        "name": "<computed: sym1>",
-        "startLine": 92,
-        "startColumn": 5,
+        "name": "D.stringLiteral4",
+        "startLine": 94,
+        "startColumn": 29,
         "endLine": 96,
+        "endColumn": 5
+    },
+    {
+        "name": "D.prototype.abc",
+        "startLine": 96,
+        "startColumn": 6,
+        "endLine": 100,
+        "endColumn": 5
+    },
+    {
+        "name": "D.def",
+        "startLine": 100,
+        "startColumn": 5,
+        "endLine": 104,
+        "endColumn": 5
+    },
+    {
+        "name": "D.xyz",
+        "startLine": 106,
+        "startColumn": 20,
+        "endLine": 108,
+        "endColumn": 5
+    },
+    {
+        "name": "42",
+        "startLine": 110,
+        "startColumn": 8,
+        "endLine": 113,
+        "endColumn": 5
+    },
+    {
+        "name": "D.prototype.43",
+        "startLine": 113,
+        "startColumn": 6,
+        "endLine": 117,
+        "endColumn": 5
+    },
+    {
+        "name": "D.prototype.44",
+        "startLine": 117,
+        "startColumn": 5,
+        "endLine": 121,
+        "endColumn": 5
+    },
+    {
+        "name": "D.45",
+        "startLine": 121,
+        "startColumn": 5,
+        "endLine": 125,
+        "endColumn": 5
+    },
+    {
+        "name": "D.46",
+        "startLine": 125,
+        "startColumn": 5,
+        "endLine": 129,
+        "endColumn": 5
+    },
+    {
+        "name": "D.47",
+        "startLine": 131,
+        "startColumn": 15,
+        "endLine": 133,
+        "endColumn": 5
+    },
+    {
+        "name": "D.48",
+        "startLine": 135,
+        "startColumn": 17,
+        "endLine": 137,
+        "endColumn": 5
+    },
+    {
+        "name": "D.prototype.<computed>",
+        "startLine": 137,
+        "startColumn": 6,
+        "endLine": 141,
+        "endColumn": 5
+    },
+    {
+        "name": "D.<computed>",
+        "startLine": 141,
+        "startColumn": 5,
+        "endLine": 145,
+        "endColumn": 5
+    },
+    {
+        "name": "D.prototype.<computed: sym1>",
+        "startLine": 145,
+        "startColumn": 5,
+        "endLine": 149,
         "endColumn": 5
     }
 ]

--- a/tests/fixtures/parser/classVariations.ts
+++ b/tests/fixtures/parser/classVariations.ts
@@ -1,0 +1,90 @@
+class A {
+    constructor() {}        // A
+    f() {}                  // A.prototype.f
+    static g(){}            // A.g
+    h = function(){}        // h
+    static i = function(){} // A.i
+}
+
+const B = class {
+    constructor(){}         // B
+    f(){}                   // B.prototype.f
+    static g(){}            // B.g
+    h = function(){}        // h
+    static i = function(){} // B.i
+}
+
+const C = class LocalName {
+    constructor(){}         // LocalName
+    f(){}                   // LocalName.prototype.f
+    static g(){}            // LocalName.g
+    h = function(){}        // h
+    static i = function(){} // LocalName.i
+}
+
+let a = { 
+    B: class {
+        constructor(){}             // a.B
+        f(){}                       // a.B.prototype.f
+        static g(){}                // a.B.g
+        h = function(){}            // h
+        static i = function(){}     // a.B.i
+    }
+}
+
+let x = { 
+    y: class LocalName {
+        constructor(){}         // LocalName
+        f(){}                   // LocalName.prototype.f
+        static g(){}            // LocalName.g
+        h = function(){}        // h
+        static i = function(){} // LocalName.i
+    }
+}
+
+a.B = class {
+    constructor(){}         // a.B
+    f(){}                   // a.B.prototype.f
+    static g(){}            // a.B.g
+    h = function(){}        // h
+    static i = function(){} // a.B.i
+}
+
+x.y = class LocalName {
+    constructor(){}         // LocalName
+    f(){}                   // LocalName.prototype.f
+    static g(){}            // LocalName.g
+    h = function(){}        // h
+    static i = function(){} // LocalName.i
+}
+
+let m = {
+    n: {
+        O: class {
+            constructor(){}                 // m.n.O
+            p = function(){}                // p
+            q = function localName(){ }     // localName
+            r(){}                           // m.n.O.prototype.r
+            static s(){}                    // m.n.O.s
+            static t = function(){}         // m.n.O.t
+            get a(){return 5;}              // m.n.O.prototype.get a
+        }, 
+        W: class LocalName {
+            constructor(){}                 // LocalName
+            p = function(){}                // p
+            q = function localName(){ }     // localName
+            r(){}                           // LocalName.prototype.r
+            static s(){}                    // LocalName.s
+            static t = function(){}         // LocalName.t
+            get a(){return 5;}              // LocalName.prototype.get a
+        }, 
+        ["Q"]: class {
+            r(){}                           // m.n.Q.prototype.r
+        }, 
+        ["Q" + "Z"]: class {
+            r(){}                           // m.n.<computed>.prototype.r
+        }
+    }
+}
+
+

--- a/tests/fixtures/parser/classVariations.ts
+++ b/tests/fixtures/parser/classVariations.ts
@@ -1,25 +1,37 @@
 class A {
-    constructor() {}        // A
-    f() {}                  // A.prototype.f
-    static g(){}            // A.g
-    h = function(){}        // h
-    static i = function(){} // A.i
+    constructor() {}            // A
+    f() {}                      // A.prototype.f
+    static g(){}                // A.g
+    h = function(){}            // h
+    static i = function(){}     // A.i
+    get j() {return 1;}         // A.prototype.get j
+    set j(p){}                  // A.prototype.set j
+    static get K(){return 1;}   // A.get K
+    static set K(p){}           // A.set K
 }
 
 const B = class {
-    constructor(){}         // B
-    f(){}                   // B.prototype.f
-    static g(){}            // B.g
-    h = function(){}        // h
-    static i = function(){} // B.i
+    constructor(){}             // B
+    f(){}                       // B.prototype.f
+    static g(){}                // B.g
+    h = function(){}            // h
+    static i = function(){}     // B.i
+    get j() {return 1;}         // B.prototype.get j
+    set j(p){}                  // B.prototype.set j
+    static get K(){return 1;}   // B.get K
+    static set K(p){}           // B.set K
 }
 
 const C = class LocalName {
-    constructor(){}         // LocalName
-    f(){}                   // LocalName.prototype.f
-    static g(){}            // LocalName.g
-    h = function(){}        // h
-    static i = function(){} // LocalName.i
+    constructor(){}             // LocalName
+    f(){}                       // LocalName.prototype.f
+    static g(){}                // LocalName.g
+    h = function(){}            // h
+    static i = function(){}     // LocalName.i
+    get j() {return 1;}         // LocalName.prototype.get j
+    set j(p){}                  // LocalName.prototype.set j
+    static get K(){return 1;}   // LocalName.get K
+    static set K(p){}           // LocalName.set K
 }
 
 let a = { 
@@ -29,33 +41,49 @@ let a = {
         static g(){}                // a.B.g
         h = function(){}            // h
         static i = function(){}     // a.B.i
+        get j() {return 1;}         // a.B.prototype.get j
+        set j(p){}                  // a.B.prototype.set j
+        static get K(){return 1;}   // a.B.get K
+        static set K(p){}           // a.B.set K
     }
 }
 
 let x = { 
     y: class LocalName {
-        constructor(){}         // LocalName
-        f(){}                   // LocalName.prototype.f
-        static g(){}            // LocalName.g
-        h = function(){}        // h
-        static i = function(){} // LocalName.i
+        constructor(){}             // LocalName
+        f(){}                       // LocalName.prototype.f
+        static g(){}                // LocalName.g
+        h = function(){}            // h
+        static i = function(){}     // LocalName.i
+        get j() {return 1;}         // LocalName.prototype.get j
+        set j(p){}                  // LocalName.prototype.set j
+        static get K(){return 1;}   // LocalName.get K
+        static set K(p){}           // LocalName.set K
     }
 }
 
 a.B = class {
-    constructor(){}         // a.B
-    f(){}                   // a.B.prototype.f
-    static g(){}            // a.B.g
-    h = function(){}        // h
-    static i = function(){} // a.B.i
+    constructor(){}             // a.B
+    f(){}                       // a.B.prototype.f
+    static g(){}                // a.B.g
+    h = function(){}            // h
+    static i = function(){}     // a.B.i
+    get j() {return 1;}         // a.B.prototype.get j
+    set j(p){}                  // a.B.prototype.set j
+    static get K(){return 1;}   // a.B.get K
+    static set K(p){}           // a.B.set K
 }
 
 x.y = class LocalName {
-    constructor(){}         // LocalName
-    f(){}                   // LocalName.prototype.f
-    static g(){}            // LocalName.g
-    h = function(){}        // h
-    static i = function(){} // LocalName.i
+    constructor(){}             // LocalName
+    f(){}                       // LocalName.prototype.f
+    static g(){}                // LocalName.g
+    h = function(){}            // h
+    static i = function(){}     // LocalName.i
+    get j() {return 1;}         // LocalName.prototype.get j
+    set j(p){}                  // LocalName.prototype.set j
+    static get K(){return 1;}   // LocalName.get K
+    static set K(p){}           // LocalName.set K
 }
 
 let m = {

--- a/tests/fixtures/parser/classVariations.ts.function_descs.json
+++ b/tests/fixtures/parser/classVariations.ts.function_descs.json
@@ -1,0 +1,366 @@
+[
+    {
+        "name": "<top-level>",
+        "startLine": 0,
+        "startColumn": 0,
+        "endLine": 90,
+        "endColumn": 0
+    },
+    {
+        "name": "A",
+        "startLine": 0,
+        "startColumn": 9,
+        "endLine": 1,
+        "endColumn": 20
+    },
+    {
+        "name": "A.prototype.f",
+        "startLine": 1,
+        "startColumn": 20,
+        "endLine": 2,
+        "endColumn": 10
+    },
+    {
+        "name": "A.g",
+        "startLine": 2,
+        "startColumn": 10,
+        "endLine": 3,
+        "endColumn": 16
+    },
+    {
+        "name": "h",
+        "startLine": 4,
+        "startColumn": 7,
+        "endLine": 4,
+        "endColumn": 20
+    },
+    {
+        "name": "A.i",
+        "startLine": 5,
+        "startColumn": 14,
+        "endLine": 5,
+        "endColumn": 27
+    },
+    {
+        "name": "B",
+        "startLine": 8,
+        "startColumn": 17,
+        "endLine": 9,
+        "endColumn": 19
+    },
+    {
+        "name": "B.prototype.f",
+        "startLine": 9,
+        "startColumn": 19,
+        "endLine": 10,
+        "endColumn": 9
+    },
+    {
+        "name": "B.g",
+        "startLine": 10,
+        "startColumn": 9,
+        "endLine": 11,
+        "endColumn": 16
+    },
+    {
+        "name": "h",
+        "startLine": 12,
+        "startColumn": 7,
+        "endLine": 12,
+        "endColumn": 20
+    },
+    {
+        "name": "B.i",
+        "startLine": 13,
+        "startColumn": 14,
+        "endLine": 13,
+        "endColumn": 27
+    },
+    {
+        "name": "LocalName",
+        "startLine": 16,
+        "startColumn": 27,
+        "endLine": 17,
+        "endColumn": 19
+    },
+    {
+        "name": "LocalName.prototype.f",
+        "startLine": 17,
+        "startColumn": 19,
+        "endLine": 18,
+        "endColumn": 9
+    },
+    {
+        "name": "LocalName.g",
+        "startLine": 18,
+        "startColumn": 9,
+        "endLine": 19,
+        "endColumn": 16
+    },
+    {
+        "name": "h",
+        "startLine": 20,
+        "startColumn": 7,
+        "endLine": 20,
+        "endColumn": 20
+    },
+    {
+        "name": "LocalName.i",
+        "startLine": 21,
+        "startColumn": 14,
+        "endLine": 21,
+        "endColumn": 27
+    },
+    {
+        "name": "a.B",
+        "startLine": 25,
+        "startColumn": 14,
+        "endLine": 26,
+        "endColumn": 23
+    },
+    {
+        "name": "a.B.prototype.f",
+        "startLine": 26,
+        "startColumn": 23,
+        "endLine": 27,
+        "endColumn": 13
+    },
+    {
+        "name": "a.B.g",
+        "startLine": 27,
+        "startColumn": 13,
+        "endLine": 28,
+        "endColumn": 20
+    },
+    {
+        "name": "h",
+        "startLine": 29,
+        "startColumn": 11,
+        "endLine": 29,
+        "endColumn": 24
+    },
+    {
+        "name": "a.B.i",
+        "startLine": 30,
+        "startColumn": 18,
+        "endLine": 30,
+        "endColumn": 31
+    },
+    {
+        "name": "LocalName",
+        "startLine": 35,
+        "startColumn": 24,
+        "endLine": 36,
+        "endColumn": 23
+    },
+    {
+        "name": "LocalName.prototype.f",
+        "startLine": 36,
+        "startColumn": 23,
+        "endLine": 37,
+        "endColumn": 13
+    },
+    {
+        "name": "LocalName.g",
+        "startLine": 37,
+        "startColumn": 13,
+        "endLine": 38,
+        "endColumn": 20
+    },
+    {
+        "name": "h",
+        "startLine": 39,
+        "startColumn": 11,
+        "endLine": 39,
+        "endColumn": 24
+    },
+    {
+        "name": "LocalName.i",
+        "startLine": 40,
+        "startColumn": 18,
+        "endLine": 40,
+        "endColumn": 31
+    },
+    {
+        "name": "a.B",
+        "startLine": 44,
+        "startColumn": 13,
+        "endLine": 45,
+        "endColumn": 19
+    },
+    {
+        "name": "a.B.prototype.f",
+        "startLine": 45,
+        "startColumn": 19,
+        "endLine": 46,
+        "endColumn": 9
+    },
+    {
+        "name": "a.B.g",
+        "startLine": 46,
+        "startColumn": 9,
+        "endLine": 47,
+        "endColumn": 16
+    },
+    {
+        "name": "h",
+        "startLine": 48,
+        "startColumn": 7,
+        "endLine": 48,
+        "endColumn": 20
+    },
+    {
+        "name": "a.B.i",
+        "startLine": 49,
+        "startColumn": 14,
+        "endLine": 49,
+        "endColumn": 27
+    },
+    {
+        "name": "LocalName",
+        "startLine": 52,
+        "startColumn": 23,
+        "endLine": 53,
+        "endColumn": 19
+    },
+    {
+        "name": "LocalName.prototype.f",
+        "startLine": 53,
+        "startColumn": 19,
+        "endLine": 54,
+        "endColumn": 9
+    },
+    {
+        "name": "LocalName.g",
+        "startLine": 54,
+        "startColumn": 9,
+        "endLine": 55,
+        "endColumn": 16
+    },
+    {
+        "name": "h",
+        "startLine": 56,
+        "startColumn": 7,
+        "endLine": 56,
+        "endColumn": 20
+    },
+    {
+        "name": "LocalName.i",
+        "startLine": 57,
+        "startColumn": 14,
+        "endLine": 57,
+        "endColumn": 27
+    },
+    {
+        "name": "m.n.O",
+        "startLine": 62,
+        "startColumn": 18,
+        "endLine": 63,
+        "endColumn": 27
+    },
+    {
+        "name": "p",
+        "startLine": 64,
+        "startColumn": 15,
+        "endLine": 64,
+        "endColumn": 28
+    },
+    {
+        "name": "localName",
+        "startLine": 65,
+        "startColumn": 15,
+        "endLine": 65,
+        "endColumn": 39
+    },
+    {
+        "name": "m.n.O.prototype.r",
+        "startLine": 65,
+        "startColumn": 39,
+        "endLine": 66,
+        "endColumn": 17
+    },
+    {
+        "name": "m.n.O.s",
+        "startLine": 66,
+        "startColumn": 17,
+        "endLine": 67,
+        "endColumn": 24
+    },
+    {
+        "name": "m.n.O.t",
+        "startLine": 68,
+        "startColumn": 22,
+        "endLine": 68,
+        "endColumn": 35
+    },
+    {
+        "name": "m.n.O.prototype.get a",
+        "startLine": 68,
+        "startColumn": 35,
+        "endLine": 69,
+        "endColumn": 30
+    },
+    {
+        "name": "LocalName",
+        "startLine": 71,
+        "startColumn": 28,
+        "endLine": 72,
+        "endColumn": 27
+    },
+    {
+        "name": "p",
+        "startLine": 73,
+        "startColumn": 15,
+        "endLine": 73,
+        "endColumn": 28
+    },
+    {
+        "name": "localName",
+        "startLine": 74,
+        "startColumn": 15,
+        "endLine": 74,
+        "endColumn": 39
+    },
+    {
+        "name": "LocalName.prototype.r",
+        "startLine": 74,
+        "startColumn": 39,
+        "endLine": 75,
+        "endColumn": 17
+    },
+    {
+        "name": "LocalName.s",
+        "startLine": 75,
+        "startColumn": 17,
+        "endLine": 76,
+        "endColumn": 24
+    },
+    {
+        "name": "LocalName.t",
+        "startLine": 77,
+        "startColumn": 22,
+        "endLine": 77,
+        "endColumn": 35
+    },
+    {
+        "name": "LocalName.prototype.get a",
+        "startLine": 77,
+        "startColumn": 35,
+        "endLine": 78,
+        "endColumn": 30
+    },
+    {
+        "name": "m.n.Q.prototype.r",
+        "startLine": 80,
+        "startColumn": 22,
+        "endLine": 81,
+        "endColumn": 17
+    },
+    {
+        "name": "m.n.<computed>.prototype.r",
+        "startLine": 83,
+        "startColumn": 28,
+        "endLine": 84,
+        "endColumn": 17
+    }
+]

--- a/tests/fixtures/parser/classVariations.ts.function_descs.json
+++ b/tests/fixtures/parser/classVariations.ts.function_descs.json
@@ -3,7 +3,7 @@
         "name": "<top-level>",
         "startLine": 0,
         "startColumn": 0,
-        "endLine": 90,
+        "endLine": 118,
         "endColumn": 0
     },
     {
@@ -42,325 +42,521 @@
         "endColumn": 27
     },
     {
-        "name": "B",
+        "name": "A.prototype.get j",
+        "startLine": 5,
+        "startColumn": 27,
+        "endLine": 6,
+        "endColumn": 23
+    },
+    {
+        "name": "A.prototype.set j",
+        "startLine": 6,
+        "startColumn": 23,
+        "endLine": 7,
+        "endColumn": 14
+    },
+    {
+        "name": "A.get K",
+        "startLine": 7,
+        "startColumn": 14,
+        "endLine": 8,
+        "endColumn": 29
+    },
+    {
+        "name": "A.set K",
         "startLine": 8,
-        "startColumn": 17,
+        "startColumn": 29,
         "endLine": 9,
+        "endColumn": 21
+    },
+    {
+        "name": "B",
+        "startLine": 12,
+        "startColumn": 17,
+        "endLine": 13,
         "endColumn": 19
     },
     {
         "name": "B.prototype.f",
-        "startLine": 9,
+        "startLine": 13,
         "startColumn": 19,
-        "endLine": 10,
+        "endLine": 14,
         "endColumn": 9
     },
     {
         "name": "B.g",
-        "startLine": 10,
+        "startLine": 14,
         "startColumn": 9,
-        "endLine": 11,
+        "endLine": 15,
         "endColumn": 16
     },
     {
         "name": "h",
-        "startLine": 12,
+        "startLine": 16,
         "startColumn": 7,
-        "endLine": 12,
+        "endLine": 16,
         "endColumn": 20
     },
     {
         "name": "B.i",
-        "startLine": 13,
+        "startLine": 17,
         "startColumn": 14,
-        "endLine": 13,
+        "endLine": 17,
         "endColumn": 27
     },
     {
-        "name": "LocalName",
-        "startLine": 16,
+        "name": "B.prototype.get j",
+        "startLine": 17,
         "startColumn": 27,
-        "endLine": 17,
+        "endLine": 18,
+        "endColumn": 23
+    },
+    {
+        "name": "B.prototype.set j",
+        "startLine": 18,
+        "startColumn": 23,
+        "endLine": 19,
+        "endColumn": 14
+    },
+    {
+        "name": "B.get K",
+        "startLine": 19,
+        "startColumn": 14,
+        "endLine": 20,
+        "endColumn": 29
+    },
+    {
+        "name": "B.set K",
+        "startLine": 20,
+        "startColumn": 29,
+        "endLine": 21,
+        "endColumn": 21
+    },
+    {
+        "name": "LocalName",
+        "startLine": 24,
+        "startColumn": 27,
+        "endLine": 25,
         "endColumn": 19
     },
     {
         "name": "LocalName.prototype.f",
-        "startLine": 17,
+        "startLine": 25,
         "startColumn": 19,
-        "endLine": 18,
+        "endLine": 26,
         "endColumn": 9
     },
     {
         "name": "LocalName.g",
-        "startLine": 18,
+        "startLine": 26,
         "startColumn": 9,
-        "endLine": 19,
+        "endLine": 27,
         "endColumn": 16
     },
     {
         "name": "h",
-        "startLine": 20,
+        "startLine": 28,
         "startColumn": 7,
-        "endLine": 20,
-        "endColumn": 20
-    },
-    {
-        "name": "LocalName.i",
-        "startLine": 21,
-        "startColumn": 14,
-        "endLine": 21,
-        "endColumn": 27
-    },
-    {
-        "name": "a.B",
-        "startLine": 25,
-        "startColumn": 14,
-        "endLine": 26,
-        "endColumn": 23
-    },
-    {
-        "name": "a.B.prototype.f",
-        "startLine": 26,
-        "startColumn": 23,
-        "endLine": 27,
-        "endColumn": 13
-    },
-    {
-        "name": "a.B.g",
-        "startLine": 27,
-        "startColumn": 13,
         "endLine": 28,
         "endColumn": 20
     },
     {
-        "name": "h",
+        "name": "LocalName.i",
         "startLine": 29,
-        "startColumn": 11,
+        "startColumn": 14,
         "endLine": 29,
+        "endColumn": 27
+    },
+    {
+        "name": "LocalName.prototype.get j",
+        "startLine": 29,
+        "startColumn": 27,
+        "endLine": 30,
+        "endColumn": 23
+    },
+    {
+        "name": "LocalName.prototype.set j",
+        "startLine": 30,
+        "startColumn": 23,
+        "endLine": 31,
+        "endColumn": 14
+    },
+    {
+        "name": "LocalName.get K",
+        "startLine": 31,
+        "startColumn": 14,
+        "endLine": 32,
+        "endColumn": 29
+    },
+    {
+        "name": "LocalName.set K",
+        "startLine": 32,
+        "startColumn": 29,
+        "endLine": 33,
+        "endColumn": 21
+    },
+    {
+        "name": "a.B",
+        "startLine": 37,
+        "startColumn": 14,
+        "endLine": 38,
+        "endColumn": 23
+    },
+    {
+        "name": "a.B.prototype.f",
+        "startLine": 38,
+        "startColumn": 23,
+        "endLine": 39,
+        "endColumn": 13
+    },
+    {
+        "name": "a.B.g",
+        "startLine": 39,
+        "startColumn": 13,
+        "endLine": 40,
+        "endColumn": 20
+    },
+    {
+        "name": "h",
+        "startLine": 41,
+        "startColumn": 11,
+        "endLine": 41,
         "endColumn": 24
     },
     {
         "name": "a.B.i",
-        "startLine": 30,
+        "startLine": 42,
         "startColumn": 18,
-        "endLine": 30,
+        "endLine": 42,
         "endColumn": 31
     },
     {
+        "name": "a.B.prototype.get j",
+        "startLine": 42,
+        "startColumn": 31,
+        "endLine": 43,
+        "endColumn": 27
+    },
+    {
+        "name": "a.B.prototype.set j",
+        "startLine": 43,
+        "startColumn": 27,
+        "endLine": 44,
+        "endColumn": 18
+    },
+    {
+        "name": "a.B.get K",
+        "startLine": 44,
+        "startColumn": 18,
+        "endLine": 45,
+        "endColumn": 33
+    },
+    {
+        "name": "a.B.set K",
+        "startLine": 45,
+        "startColumn": 33,
+        "endLine": 46,
+        "endColumn": 25
+    },
+    {
         "name": "LocalName",
-        "startLine": 35,
+        "startLine": 51,
         "startColumn": 24,
-        "endLine": 36,
+        "endLine": 52,
         "endColumn": 23
     },
     {
         "name": "LocalName.prototype.f",
-        "startLine": 36,
+        "startLine": 52,
         "startColumn": 23,
-        "endLine": 37,
+        "endLine": 53,
         "endColumn": 13
     },
     {
         "name": "LocalName.g",
-        "startLine": 37,
+        "startLine": 53,
         "startColumn": 13,
-        "endLine": 38,
+        "endLine": 54,
         "endColumn": 20
     },
     {
         "name": "h",
-        "startLine": 39,
+        "startLine": 55,
         "startColumn": 11,
-        "endLine": 39,
+        "endLine": 55,
         "endColumn": 24
     },
     {
         "name": "LocalName.i",
-        "startLine": 40,
+        "startLine": 56,
         "startColumn": 18,
-        "endLine": 40,
+        "endLine": 56,
         "endColumn": 31
     },
     {
-        "name": "a.B",
-        "startLine": 44,
-        "startColumn": 13,
-        "endLine": 45,
-        "endColumn": 19
-    },
-    {
-        "name": "a.B.prototype.f",
-        "startLine": 45,
-        "startColumn": 19,
-        "endLine": 46,
-        "endColumn": 9
-    },
-    {
-        "name": "a.B.g",
-        "startLine": 46,
-        "startColumn": 9,
-        "endLine": 47,
-        "endColumn": 16
-    },
-    {
-        "name": "h",
-        "startLine": 48,
-        "startColumn": 7,
-        "endLine": 48,
-        "endColumn": 20
-    },
-    {
-        "name": "a.B.i",
-        "startLine": 49,
-        "startColumn": 14,
-        "endLine": 49,
-        "endColumn": 27
-    },
-    {
-        "name": "LocalName",
-        "startLine": 52,
-        "startColumn": 23,
-        "endLine": 53,
-        "endColumn": 19
-    },
-    {
-        "name": "LocalName.prototype.f",
-        "startLine": 53,
-        "startColumn": 19,
-        "endLine": 54,
-        "endColumn": 9
-    },
-    {
-        "name": "LocalName.g",
-        "startLine": 54,
-        "startColumn": 9,
-        "endLine": 55,
-        "endColumn": 16
-    },
-    {
-        "name": "h",
+        "name": "LocalName.prototype.get j",
         "startLine": 56,
-        "startColumn": 7,
-        "endLine": 56,
-        "endColumn": 20
-    },
-    {
-        "name": "LocalName.i",
-        "startLine": 57,
-        "startColumn": 14,
+        "startColumn": 31,
         "endLine": 57,
         "endColumn": 27
     },
     {
-        "name": "m.n.O",
-        "startLine": 62,
+        "name": "LocalName.prototype.set j",
+        "startLine": 57,
+        "startColumn": 27,
+        "endLine": 58,
+        "endColumn": 18
+    },
+    {
+        "name": "LocalName.get K",
+        "startLine": 58,
         "startColumn": 18,
-        "endLine": 63,
+        "endLine": 59,
+        "endColumn": 33
+    },
+    {
+        "name": "LocalName.set K",
+        "startLine": 59,
+        "startColumn": 33,
+        "endLine": 60,
+        "endColumn": 25
+    },
+    {
+        "name": "a.B",
+        "startLine": 64,
+        "startColumn": 13,
+        "endLine": 65,
+        "endColumn": 19
+    },
+    {
+        "name": "a.B.prototype.f",
+        "startLine": 65,
+        "startColumn": 19,
+        "endLine": 66,
+        "endColumn": 9
+    },
+    {
+        "name": "a.B.g",
+        "startLine": 66,
+        "startColumn": 9,
+        "endLine": 67,
+        "endColumn": 16
+    },
+    {
+        "name": "h",
+        "startLine": 68,
+        "startColumn": 7,
+        "endLine": 68,
+        "endColumn": 20
+    },
+    {
+        "name": "a.B.i",
+        "startLine": 69,
+        "startColumn": 14,
+        "endLine": 69,
+        "endColumn": 27
+    },
+    {
+        "name": "a.B.prototype.get j",
+        "startLine": 69,
+        "startColumn": 27,
+        "endLine": 70,
+        "endColumn": 23
+    },
+    {
+        "name": "a.B.prototype.set j",
+        "startLine": 70,
+        "startColumn": 23,
+        "endLine": 71,
+        "endColumn": 14
+    },
+    {
+        "name": "a.B.get K",
+        "startLine": 71,
+        "startColumn": 14,
+        "endLine": 72,
+        "endColumn": 29
+    },
+    {
+        "name": "a.B.set K",
+        "startLine": 72,
+        "startColumn": 29,
+        "endLine": 73,
+        "endColumn": 21
+    },
+    {
+        "name": "LocalName",
+        "startLine": 76,
+        "startColumn": 23,
+        "endLine": 77,
+        "endColumn": 19
+    },
+    {
+        "name": "LocalName.prototype.f",
+        "startLine": 77,
+        "startColumn": 19,
+        "endLine": 78,
+        "endColumn": 9
+    },
+    {
+        "name": "LocalName.g",
+        "startLine": 78,
+        "startColumn": 9,
+        "endLine": 79,
+        "endColumn": 16
+    },
+    {
+        "name": "h",
+        "startLine": 80,
+        "startColumn": 7,
+        "endLine": 80,
+        "endColumn": 20
+    },
+    {
+        "name": "LocalName.i",
+        "startLine": 81,
+        "startColumn": 14,
+        "endLine": 81,
+        "endColumn": 27
+    },
+    {
+        "name": "LocalName.prototype.get j",
+        "startLine": 81,
+        "startColumn": 27,
+        "endLine": 82,
+        "endColumn": 23
+    },
+    {
+        "name": "LocalName.prototype.set j",
+        "startLine": 82,
+        "startColumn": 23,
+        "endLine": 83,
+        "endColumn": 14
+    },
+    {
+        "name": "LocalName.get K",
+        "startLine": 83,
+        "startColumn": 14,
+        "endLine": 84,
+        "endColumn": 29
+    },
+    {
+        "name": "LocalName.set K",
+        "startLine": 84,
+        "startColumn": 29,
+        "endLine": 85,
+        "endColumn": 21
+    },
+    {
+        "name": "m.n.O",
+        "startLine": 90,
+        "startColumn": 18,
+        "endLine": 91,
         "endColumn": 27
     },
     {
         "name": "p",
-        "startLine": 64,
+        "startLine": 92,
         "startColumn": 15,
-        "endLine": 64,
+        "endLine": 92,
         "endColumn": 28
     },
     {
         "name": "localName",
-        "startLine": 65,
+        "startLine": 93,
         "startColumn": 15,
-        "endLine": 65,
+        "endLine": 93,
         "endColumn": 39
     },
     {
         "name": "m.n.O.prototype.r",
-        "startLine": 65,
+        "startLine": 93,
         "startColumn": 39,
-        "endLine": 66,
+        "endLine": 94,
         "endColumn": 17
     },
     {
         "name": "m.n.O.s",
-        "startLine": 66,
+        "startLine": 94,
         "startColumn": 17,
-        "endLine": 67,
+        "endLine": 95,
         "endColumn": 24
     },
     {
         "name": "m.n.O.t",
-        "startLine": 68,
+        "startLine": 96,
         "startColumn": 22,
-        "endLine": 68,
+        "endLine": 96,
         "endColumn": 35
     },
     {
         "name": "m.n.O.prototype.get a",
-        "startLine": 68,
+        "startLine": 96,
         "startColumn": 35,
-        "endLine": 69,
+        "endLine": 97,
         "endColumn": 30
     },
     {
         "name": "LocalName",
-        "startLine": 71,
+        "startLine": 99,
         "startColumn": 28,
-        "endLine": 72,
+        "endLine": 100,
         "endColumn": 27
     },
     {
         "name": "p",
-        "startLine": 73,
+        "startLine": 101,
         "startColumn": 15,
-        "endLine": 73,
+        "endLine": 101,
         "endColumn": 28
     },
     {
         "name": "localName",
-        "startLine": 74,
+        "startLine": 102,
         "startColumn": 15,
-        "endLine": 74,
+        "endLine": 102,
         "endColumn": 39
     },
     {
         "name": "LocalName.prototype.r",
-        "startLine": 74,
+        "startLine": 102,
         "startColumn": 39,
-        "endLine": 75,
+        "endLine": 103,
         "endColumn": 17
     },
     {
         "name": "LocalName.s",
-        "startLine": 75,
+        "startLine": 103,
         "startColumn": 17,
-        "endLine": 76,
+        "endLine": 104,
         "endColumn": 24
     },
     {
         "name": "LocalName.t",
-        "startLine": 77,
+        "startLine": 105,
         "startColumn": 22,
-        "endLine": 77,
+        "endLine": 105,
         "endColumn": 35
     },
     {
         "name": "LocalName.prototype.get a",
-        "startLine": 77,
+        "startLine": 105,
         "startColumn": 35,
-        "endLine": 78,
+        "endLine": 106,
         "endColumn": 30
     },
     {
         "name": "m.n.Q.prototype.r",
-        "startLine": 80,
+        "startLine": 108,
         "startColumn": 22,
-        "endLine": 81,
+        "endLine": 109,
         "endColumn": 17
     },
     {
         "name": "m.n.<computed>.prototype.r",
-        "startLine": 83,
+        "startLine": 111,
         "startColumn": 28,
-        "endLine": 84,
+        "endLine": 112,
         "endColumn": 17
     }
 ]

--- a/tests/fixtures/parser/generator.js.function_descs.json
+++ b/tests/fixtures/parser/generator.js.function_descs.json
@@ -21,14 +21,14 @@
         "endColumn": 1
     },
     {
-        "name": "f3",
+        "name": "obj.f3",
         "startLine": 12,
         "startColumn": 13,
         "endLine": 15,
         "endColumn": 5
     },
     {
-        "name": "f4",
+        "name": "MyClass.prototype.f4",
         "startLine": 19,
         "startColumn": 15,
         "endLine": 22,

--- a/tests/fixtures/parser/objectLiteral.js.function_descs.json
+++ b/tests/fixtures/parser/objectLiteral.js.function_descs.json
@@ -7,14 +7,14 @@
         "endColumn": 2
     },
     {
-        "name": "f1",
+        "name": "obj.f1",
         "startLine": 2,
         "startColumn": 13,
         "endLine": 5,
         "endColumn": 5
     },
     {
-        "name": "f2",
+        "name": "obj.f2",
         "startLine": 6,
         "startColumn": 7,
         "endLine": 8,
@@ -28,119 +28,119 @@
         "endColumn": 5
     },
     {
-        "name": "f4",
+        "name": "obj.f4",
         "startLine": 12,
         "startColumn": 7,
         "endLine": 14,
         "endColumn": 5
     },
     {
-        "name": "f5",
+        "name": "obj.f5",
         "startLine": 14,
         "startColumn": 6,
         "endLine": 17,
         "endColumn": 5
     },
     {
-        "name": "f6",
+        "name": "obj.f6",
         "startLine": 17,
         "startColumn": 6,
         "endLine": 20,
         "endColumn": 5
     },
     {
-        "name": "literal",
+        "name": "obj.literal",
         "startLine": 20,
         "startColumn": 6,
         "endLine": 23,
         "endColumn": 5
     },
     {
-        "name": "literal2",
+        "name": "obj.literal2",
         "startLine": 24,
         "startColumn": 15,
         "endLine": 26,
         "endColumn": 5
     },
     {
-        "name": " literal 3 ",
+        "name": "obj. literal 3 ",
         "startLine": 26,
         "startColumn": 6,
         "endLine": 29,
         "endColumn": 5
     },
     {
-        "name": " literail 4 ",
+        "name": "obj. literail 4 ",
         "startLine": 30,
         "startColumn": 19,
         "endLine": 32,
         "endColumn": 5
     },
     {
-        "name": "42",
+        "name": "obj.42",
         "startLine": 32,
         "startColumn": 6,
         "endLine": 35,
         "endColumn": 5
     },
     {
-        "name": "43",
+        "name": "obj.43",
         "startLine": 36,
         "startColumn": 7,
         "endLine": 38,
         "endColumn": 5
     },
     {
-        "name": "44",
+        "name": "obj.44",
         "startLine": 38,
         "startColumn": 6,
         "endLine": 41,
         "endColumn": 5
     },
     {
-        "name": "45",
+        "name": "obj.45",
         "startLine": 41,
         "startColumn": 6,
         "endLine": 44,
         "endColumn": 5
     },
     {
-        "name": "<computed: prop1>",
+        "name": "obj.<computed: prop1>",
         "startLine": 44,
         "startColumn": 6,
         "endLine": 47,
         "endColumn": 5
     },
     {
-        "name": "<computed: prop2>",
+        "name": "obj.<computed: prop2>",
         "startLine": 47,
         "startColumn": 6,
         "endLine": 50,
         "endColumn": 5
     },
     {
-        "name": "abc",
+        "name": "obj.abc",
         "startLine": 50,
         "startColumn": 6,
         "endLine": 53,
         "endColumn": 5
     },
     {
-        "name": "abc d",
+        "name": "obj.abc d",
         "startLine": 53,
         "startColumn": 6,
         "endLine": 56,
         "endColumn": 5
     },
     {
-        "name": " a b c ",
+        "name": "obj. a b c ",
         "startLine": 56,
         "startColumn": 6,
         "endLine": 59,
         "endColumn": 5
     },
     {
-        "name": "<computed>",
+        "name": "obj.<computed>",
         "startLine": 59,
         "startColumn": 6,
         "endLine": 62,

--- a/tests/fixtures/parser/objectLiteralNesting.js
+++ b/tests/fixtures/parser/objectLiteralNesting.js
@@ -7,7 +7,9 @@ let obj1 = {
             a3: function() {},              // obj1.a1.a2.a3
             a4: () => {},                   // obj1.a1.a2.a4
             a5() {},                        // obj1.a1.a2.a5
-            a6: function localName() {}     // localName
+            a6: function localName() {},    // localName
+            get a7(){return 1;},            // obj1.a1.a2.get a7
+            set a7(p){}                     // obj1.a1.a2.set a7
         }
     },
 

--- a/tests/fixtures/parser/objectLiteralNesting.js
+++ b/tests/fixtures/parser/objectLiteralNesting.js
@@ -1,0 +1,112 @@
+let prop = "property";
+
+// variable declaration
+let obj1 = {
+    a1: {
+        a2: {
+            a3: function() {},              // obj1.a1.a2.a3
+            a4: () => {},                   // obj1.a1.a2.a4
+            a5() {},                        // obj1.a1.a2.a5
+            a6: function localName() {}     // localName
+        }
+    },
+
+    ["brown" + "fox"]: {
+        42: {
+            [43]: {
+                "literal1": {
+                    ["literal2"]: {
+                        [prop]: function() {},  // obj1.<computed>.42.43.literal1.literal2.<computed: prop>
+                        f1(){},                 // obj1.<computed>.42.43.literal1.literal2.f1
+                    }
+                }
+            }
+        }
+    }
+};
+
+// variable assignment
+let obj2;
+obj2 = {
+    a1: {
+        a2: {
+            a3: function() {},              // obj2.a1.a2.a3
+            a4: () => {},                   // obj2.a1.a2.a4
+            a5() {},                        // obj2.a1.a2.a5
+            a6: function localName() {}     // localName
+        },
+    },
+
+    ["brown" + "fox"]: {
+        42: {
+            [43]: {
+                "literal1": {
+                    ["literal2"]: {
+                        [prop]: function() {},  // obj2.<computed>.42.43.literal1.literal2.<computed: prop>
+                        f1(){},                 // obj2.<computed>.42.43.literal1.literal2.f1
+                    }
+                }
+            }
+        }
+    }
+};
+
+// object literal not assigned to anything
+function f(o) {}
+
+f({
+    a1: {
+        a2: {
+            a3: function() {},              // <Object>.a1.a2.a3
+            a4: () => {},                   // <Object>.a1.a2.a4
+            a5() {},                        // <Object>.a1.a2.a5
+            a6: function localName() {}     // localName
+        },
+    },
+
+    ["brown" + "fox"]: {
+        42: {
+            [43]: {
+                "literal1": {
+                    ["literal2"]: {
+                        [prop]: function() {},  // <Object>.<computed>.42.43.literal1.literal2.<computed: prop>
+                        f1(){},                 // <Object>.<computed>.42.43.literal1.literal2.f1
+                    }
+                }
+            }
+        }
+    }
+});
+
+// destructuring
+let { a, b } = {
+    a: {
+        c: function() {}, // <Object>.a.c
+    },
+    b: {
+        c: function() {}, // <Object>.b.c
+    },
+};
+
+// non-variable assignment
+a.b.c = {
+    d: {
+        e: function(){},    // a.b.c.d.e
+        f() {}              // a.b.c.d.f
+    }
+}
+
+a[b]["literal"].c = {
+    ["brown" + "fox"]: {
+        42: {
+            [43]: {
+                "literal1": {
+                    ["literal2"]: {
+                        [prop]: function() {},  // a.<computed: b>.literal.c.<computed>.42.43.literal1.literal2.<computed: prop>
+                        f1(){}                  // a.<computed: b>.literal.c.<computed>.42.43.literal1.literal2.f1
+                    }
+                }
+            }
+        }
+    }
+};

--- a/tests/fixtures/parser/objectLiteralNesting.js.function_descs.json
+++ b/tests/fixtures/parser/objectLiteralNesting.js.function_descs.json
@@ -3,7 +3,7 @@
         "name": "<top-level>",
         "startLine": 0,
         "startColumn": 0,
-        "endLine": 112,
+        "endLine": 114,
         "endColumn": 0
     },
     {
@@ -35,150 +35,164 @@
         "endColumn": 39
     },
     {
+        "name": "obj1.a1.a2.get a7",
+        "startLine": 9,
+        "startColumn": 40,
+        "endLine": 10,
+        "endColumn": 31
+    },
+    {
+        "name": "obj1.a1.a2.set a7",
+        "startLine": 10,
+        "startColumn": 32,
+        "endLine": 11,
+        "endColumn": 23
+    },
+    {
         "name": "obj1.<computed>.42.43.literal1.literal2.<computed: prop>",
-        "startLine": 18,
+        "startLine": 20,
         "startColumn": 31,
-        "endLine": 18,
+        "endLine": 20,
         "endColumn": 45
     },
     {
         "name": "obj1.<computed>.42.43.literal1.literal2.f1",
-        "startLine": 18,
+        "startLine": 20,
         "startColumn": 46,
-        "endLine": 19,
+        "endLine": 21,
         "endColumn": 30
     },
     {
         "name": "obj2.a1.a2.a3",
-        "startLine": 32,
+        "startLine": 34,
         "startColumn": 15,
-        "endLine": 32,
+        "endLine": 34,
         "endColumn": 29
     },
     {
         "name": "obj2.a1.a2.a4",
-        "startLine": 33,
+        "startLine": 35,
         "startColumn": 15,
-        "endLine": 33,
+        "endLine": 35,
         "endColumn": 24
     },
     {
         "name": "obj2.a1.a2.a5",
-        "startLine": 33,
+        "startLine": 35,
         "startColumn": 25,
-        "endLine": 34,
+        "endLine": 36,
         "endColumn": 19
     },
     {
         "name": "localName",
-        "startLine": 35,
+        "startLine": 37,
         "startColumn": 15,
-        "endLine": 35,
+        "endLine": 37,
         "endColumn": 39
     },
     {
         "name": "obj2.<computed>.42.43.literal1.literal2.<computed: prop>",
-        "startLine": 44,
+        "startLine": 46,
         "startColumn": 31,
-        "endLine": 44,
+        "endLine": 46,
         "endColumn": 45
     },
     {
         "name": "obj2.<computed>.42.43.literal1.literal2.f1",
-        "startLine": 44,
+        "startLine": 46,
         "startColumn": 46,
-        "endLine": 45,
+        "endLine": 47,
         "endColumn": 30
     },
     {
         "name": "f",
-        "startLine": 51,
+        "startLine": 53,
         "startColumn": 2,
-        "endLine": 54,
+        "endLine": 56,
         "endColumn": 16
     },
     {
         "name": "<Object>.a1.a2.a3",
-        "startLine": 59,
+        "startLine": 61,
         "startColumn": 15,
-        "endLine": 59,
+        "endLine": 61,
         "endColumn": 29
     },
     {
         "name": "<Object>.a1.a2.a4",
-        "startLine": 60,
+        "startLine": 62,
         "startColumn": 15,
-        "endLine": 60,
+        "endLine": 62,
         "endColumn": 24
     },
     {
         "name": "<Object>.a1.a2.a5",
-        "startLine": 60,
+        "startLine": 62,
         "startColumn": 25,
-        "endLine": 61,
+        "endLine": 63,
         "endColumn": 19
     },
     {
         "name": "localName",
-        "startLine": 62,
+        "startLine": 64,
         "startColumn": 15,
-        "endLine": 62,
+        "endLine": 64,
         "endColumn": 39
     },
     {
         "name": "<Object>.<computed>.42.43.literal1.literal2.<computed: prop>",
-        "startLine": 71,
+        "startLine": 73,
         "startColumn": 31,
-        "endLine": 71,
+        "endLine": 73,
         "endColumn": 45
     },
     {
         "name": "<Object>.<computed>.42.43.literal1.literal2.f1",
-        "startLine": 71,
+        "startLine": 73,
         "startColumn": 46,
-        "endLine": 72,
+        "endLine": 74,
         "endColumn": 30
     },
     {
         "name": "<Object>.a.c",
-        "startLine": 83,
+        "startLine": 85,
         "startColumn": 10,
-        "endLine": 83,
+        "endLine": 85,
         "endColumn": 24
     },
     {
         "name": "<Object>.b.c",
-        "startLine": 86,
+        "startLine": 88,
         "startColumn": 10,
-        "endLine": 86,
+        "endLine": 88,
         "endColumn": 24
     },
     {
         "name": "a.b.c.d.e",
-        "startLine": 93,
+        "startLine": 95,
         "startColumn": 10,
-        "endLine": 93,
+        "endLine": 95,
         "endColumn": 23
     },
     {
         "name": "a.b.c.d.f",
-        "startLine": 93,
+        "startLine": 95,
         "startColumn": 24,
-        "endLine": 94,
+        "endLine": 96,
         "endColumn": 14
     },
     {
         "name": "a.<computed: b>.literal.c.<computed>.42.43.literal1.literal2.<computed: prop>",
-        "startLine": 104,
+        "startLine": 106,
         "startColumn": 31,
-        "endLine": 104,
+        "endLine": 106,
         "endColumn": 45
     },
     {
         "name": "a.<computed: b>.literal.c.<computed>.42.43.literal1.literal2.f1",
-        "startLine": 104,
+        "startLine": 106,
         "startColumn": 46,
-        "endLine": 105,
+        "endLine": 107,
         "endColumn": 30
     }
 ]

--- a/tests/fixtures/parser/objectLiteralNesting.js.function_descs.json
+++ b/tests/fixtures/parser/objectLiteralNesting.js.function_descs.json
@@ -1,0 +1,184 @@
+[
+    {
+        "name": "<top-level>",
+        "startLine": 0,
+        "startColumn": 0,
+        "endLine": 112,
+        "endColumn": 0
+    },
+    {
+        "name": "obj1.a1.a2.a3",
+        "startLine": 6,
+        "startColumn": 15,
+        "endLine": 6,
+        "endColumn": 29
+    },
+    {
+        "name": "obj1.a1.a2.a4",
+        "startLine": 7,
+        "startColumn": 15,
+        "endLine": 7,
+        "endColumn": 24
+    },
+    {
+        "name": "obj1.a1.a2.a5",
+        "startLine": 7,
+        "startColumn": 25,
+        "endLine": 8,
+        "endColumn": 19
+    },
+    {
+        "name": "localName",
+        "startLine": 9,
+        "startColumn": 15,
+        "endLine": 9,
+        "endColumn": 39
+    },
+    {
+        "name": "obj1.<computed>.42.43.literal1.literal2.<computed: prop>",
+        "startLine": 18,
+        "startColumn": 31,
+        "endLine": 18,
+        "endColumn": 45
+    },
+    {
+        "name": "obj1.<computed>.42.43.literal1.literal2.f1",
+        "startLine": 18,
+        "startColumn": 46,
+        "endLine": 19,
+        "endColumn": 30
+    },
+    {
+        "name": "obj2.a1.a2.a3",
+        "startLine": 32,
+        "startColumn": 15,
+        "endLine": 32,
+        "endColumn": 29
+    },
+    {
+        "name": "obj2.a1.a2.a4",
+        "startLine": 33,
+        "startColumn": 15,
+        "endLine": 33,
+        "endColumn": 24
+    },
+    {
+        "name": "obj2.a1.a2.a5",
+        "startLine": 33,
+        "startColumn": 25,
+        "endLine": 34,
+        "endColumn": 19
+    },
+    {
+        "name": "localName",
+        "startLine": 35,
+        "startColumn": 15,
+        "endLine": 35,
+        "endColumn": 39
+    },
+    {
+        "name": "obj2.<computed>.42.43.literal1.literal2.<computed: prop>",
+        "startLine": 44,
+        "startColumn": 31,
+        "endLine": 44,
+        "endColumn": 45
+    },
+    {
+        "name": "obj2.<computed>.42.43.literal1.literal2.f1",
+        "startLine": 44,
+        "startColumn": 46,
+        "endLine": 45,
+        "endColumn": 30
+    },
+    {
+        "name": "f",
+        "startLine": 51,
+        "startColumn": 2,
+        "endLine": 54,
+        "endColumn": 16
+    },
+    {
+        "name": "<Object>.a1.a2.a3",
+        "startLine": 59,
+        "startColumn": 15,
+        "endLine": 59,
+        "endColumn": 29
+    },
+    {
+        "name": "<Object>.a1.a2.a4",
+        "startLine": 60,
+        "startColumn": 15,
+        "endLine": 60,
+        "endColumn": 24
+    },
+    {
+        "name": "<Object>.a1.a2.a5",
+        "startLine": 60,
+        "startColumn": 25,
+        "endLine": 61,
+        "endColumn": 19
+    },
+    {
+        "name": "localName",
+        "startLine": 62,
+        "startColumn": 15,
+        "endLine": 62,
+        "endColumn": 39
+    },
+    {
+        "name": "<Object>.<computed>.42.43.literal1.literal2.<computed: prop>",
+        "startLine": 71,
+        "startColumn": 31,
+        "endLine": 71,
+        "endColumn": 45
+    },
+    {
+        "name": "<Object>.<computed>.42.43.literal1.literal2.f1",
+        "startLine": 71,
+        "startColumn": 46,
+        "endLine": 72,
+        "endColumn": 30
+    },
+    {
+        "name": "<Object>.a.c",
+        "startLine": 83,
+        "startColumn": 10,
+        "endLine": 83,
+        "endColumn": 24
+    },
+    {
+        "name": "<Object>.b.c",
+        "startLine": 86,
+        "startColumn": 10,
+        "endLine": 86,
+        "endColumn": 24
+    },
+    {
+        "name": "a.b.c.d.e",
+        "startLine": 93,
+        "startColumn": 10,
+        "endLine": 93,
+        "endColumn": 23
+    },
+    {
+        "name": "a.b.c.d.f",
+        "startLine": 93,
+        "startColumn": 24,
+        "endLine": 94,
+        "endColumn": 14
+    },
+    {
+        "name": "a.<computed: b>.literal.c.<computed>.42.43.literal1.literal2.<computed: prop>",
+        "startLine": 104,
+        "startColumn": 31,
+        "endLine": 104,
+        "endColumn": 45
+    },
+    {
+        "name": "a.<computed: b>.literal.c.<computed>.42.43.literal1.literal2.f1",
+        "startLine": 104,
+        "startColumn": 46,
+        "endLine": 105,
+        "endColumn": 30
+    }
+]

--- a/tests/fixtures/parser/simple.tsx.function_descs.json
+++ b/tests/fixtures/parser/simple.tsx.function_descs.json
@@ -7,7 +7,7 @@
         "endColumn": 0
     },
     {
-        "name": "createElement",
+        "name": "React.createElement",
         "startLine": 11,
         "startColumn": 18,
         "endLine": 11,

--- a/tests/fixtures/parser/typescript.ts.function_descs.json
+++ b/tests/fixtures/parser/typescript.ts.function_descs.json
@@ -35,21 +35,21 @@
         "endColumn": 1
     },
     {
-        "name": "t5",
+        "name": "o.t5",
         "startLine": 25,
         "startColumn": 7,
         "endLine": 29,
         "endColumn": 5
     },
     {
-        "name": "t6",
+        "name": "o.t6",
         "startLine": 30,
         "startColumn": 7,
         "endLine": 33,
         "endColumn": 5
     },
     {
-        "name": "t7",
+        "name": "o.t7",
         "startLine": 33,
         "startColumn": 6,
         "endLine": 36,
@@ -70,49 +70,49 @@
         "endColumn": 36
     },
     {
-        "name": "t9",
+        "name": "C.prototype.t9",
         "startLine": 46,
         "startColumn": 36,
         "endLine": 51,
         "endColumn": 5
     },
     {
-        "name": "t10",
+        "name": "C.t10",
         "startLine": 52,
         "startColumn": 23,
         "endLine": 52,
         "endColumn": 50
     },
     {
-        "name": "t11",
+        "name": "C.prototype.t11",
         "startLine": 52,
         "startColumn": 51,
         "endLine": 57,
         "endColumn": 5
     },
     {
-        "name": "<computed: sym>",
+        "name": "C.prototype.<computed: sym>",
         "startLine": 57,
         "startColumn": 5,
         "endLine": 61,
         "endColumn": 5
     },
     {
-        "name": "<computed>",
+        "name": "C.prototype.<computed>",
         "startLine": 61,
         "startColumn": 5,
         "endLine": 65,
         "endColumn": 5
     },
     {
-        "name": "get z",
+        "name": "C.prototype.get z",
         "startLine": 67,
         "startColumn": 22,
         "endLine": 71,
         "endColumn": 5
     },
     {
-        "name": "set z",
+        "name": "C.prototype.set z",
         "startLine": 71,
         "startColumn": 5,
         "endLine": 75,

--- a/tests/main.t.ts
+++ b/tests/main.t.ts
@@ -56,14 +56,14 @@ test("integration test", (t) => {
     t.deepEqual(decoder.decode("foo.js", 17, 5), "f5");
     t.deepEqual(decoder.decode("foo.js", 19, 5), "<anonymous>");
     t.deepEqual(decoder.decode("foo.js", 27, 5), "Foo");
-    t.deepEqual(decoder.decode("foo.js", 30, 5), "method1");
-    t.deepEqual(decoder.decode("foo.js", 33, 5), "get prop");
-    t.deepEqual(decoder.decode("foo.js", 36, 5), "set prop");
+    t.deepEqual(decoder.decode("foo.js", 30, 5), "Foo.prototype.method1");
+    t.deepEqual(decoder.decode("foo.js", 33, 5), "Foo.prototype.get prop");
+    t.deepEqual(decoder.decode("foo.js", 36, 5), "Foo.prototype.set prop");
     t.deepEqual(decoder.decode("foo.js", 4, 0), "<top-level>");
 
     t.deepEqual(decoder.decode("bar.js", 2, 5), "Bar");
-    t.deepEqual(decoder.decode("bar.js", 6, 5), "get prop");
-    t.deepEqual(decoder.decode("bar.js", 9, 5), "set prop");
+    t.deepEqual(decoder.decode("bar.js", 6, 5), "Bar.prototype.get prop");
+    t.deepEqual(decoder.decode("bar.js", 9, 5), "Bar.prototype.set prop");
     t.deepEqual(decoder.decode("bar.js", 14, 5), "f1");
     t.deepEqual(decoder.decode("bar.js", 18, 5), "bar1");
     t.deepEqual(decoder.decode("bar.js", 22, 5), "bar2");

--- a/tests/parser.t.ts
+++ b/tests/parser.t.ts
@@ -31,6 +31,7 @@ test("parser module tests", (t) => {
         ["nesting.js", "ECMAScript"],
         ["class.js", "ECMAScript"],
         ["objectLiteral.js", "ECMAScript"],
+        ["objectLiteralNesting.js", "ECMAScript"],
         ["typescript.ts", "TypeScript"],
         ["class.ts", "TypeScript"],
         ["simple.tsx", "TSX"],
@@ -38,6 +39,7 @@ test("parser module tests", (t) => {
         ["lhsVariations.js", "ECMAScript"],
         ["lhsVariationsArrow.js", "ECMAScript"],
         ["lhsVariationsLocalName.js", "ECMAScript"],
+        ["classVariations.ts", "TypeScript"],
     ];
 
     t.plan(CASES.length);


### PR DESCRIPTION
If a function is inside a class, prefix it with the class name (Class or Class.prototype depending on whether it's a static method or not). If the function is a class property, then don't do any prefixing. For example: 

```javascript
class MyClass {
    f(){} // name = MyClass.prototype.f
    static g(){} // name = MyClass.f
    h = function(){} // name = f
}
```

If a function appears in an object literal, prefix it with the chain of property names. For example:

```javascript
let a = {
    b: {
        f: function(){} // name = a.b.f
    }
}
```

The newly added test cases are  [tests/fixtures/parser/objectLiteralNesting.js](https://github.com/bloomberg/pasta-sourcemaps/blob/5a6fefa1d6732b248f670ceee1b20eacf154d5da/tests/fixtures/parser/objectLiteralNesting.js) and [tests/fixtures/parser/classVariations.ts](https://github.com/bloomberg/pasta-sourcemaps/blob/5a6fefa1d6732b248f670ceee1b20eacf154d5da/tests/fixtures/parser/classVariations.ts).

Signed-off-by: Lilit Darbinyan <ldarbinyan@bloomberg.net>