### PR TITLE
Add Node 10 to Travis environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
   - "8"
+  - "10"
   - "lts/*"
   - "node"
 


### PR DESCRIPTION
We currently test against:

- 8
- 12 (`lts/*`)
- 14 (`node`)

Adding Node 10 to ensure coverage of supported LTS versions. Keeping 8 around (outside LTS window now) as we specify it as the minimum engine requirement in package.json.