### PR TITLE
Support TypeScript 4.0.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1792,9 +1792,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
-      "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ=="
     },
     "uglify-js": {
       "version": "3.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
-      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
+      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
       "dev": true
     },
     "@types/minimatch": {
@@ -70,49 +70,68 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.33.0.tgz",
-      "integrity": "sha512-QV6P32Btu1sCI/kTqjTNI/8OpCYyvlGjW5vD8MpTIg+HGE5S88HtT1G+880M4bXlvXj/NjsJJG0aGcVh0DdbeQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.10.1.tgz",
+      "integrity": "sha512-PQg0emRtzZFWq6PxBcdxRH3QIQiyFO3WCVpRL3fgj5oQS3CDs3AeAKfv4DxNhzn8ITdNJGJ4D3Qw8eAJf3lXeQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.33.0",
+        "@typescript-eslint/experimental-utils": "3.10.1",
+        "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
+        "semver": "^7.3.2",
         "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        }
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.33.0.tgz",
-      "integrity": "sha512-qzPM2AuxtMrRq78LwyZa8Qn6gcY8obkIrBs1ehqmQADwkYzTE1Pb4y2W+U3rE/iFkSWcWHG2LS6MJfj6SmHApg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz",
+      "integrity": "sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.33.0",
+        "@typescript-eslint/types": "3.10.1",
+        "@typescript-eslint/typescript-estree": "3.10.1",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.33.0.tgz",
-      "integrity": "sha512-AUtmwUUhJoH6yrtxZMHbRUEMsC2G6z5NSxg9KsROOGqNXasM71I8P2NihtumlWTUCRld70vqIZ6Pm4E5PAziEA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.10.1.tgz",
+      "integrity": "sha512-Ug1RcWcrJP02hmtaXVS3axPPTTPnZjupqhgj+NnZ6BCkwSImWk/283347+x9wN+lqOdK9Eo3vsyiyDHgsmiEJw==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.33.0",
-        "@typescript-eslint/typescript-estree": "2.33.0",
+        "@typescript-eslint/experimental-utils": "3.10.1",
+        "@typescript-eslint/types": "3.10.1",
+        "@typescript-eslint/typescript-estree": "3.10.1",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
+    "@typescript-eslint/types": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.10.1.tgz",
+      "integrity": "sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==",
+      "dev": true
+    },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.33.0.tgz",
-      "integrity": "sha512-d8rY6/yUxb0+mEwTShCQF2zYQdLlqihukNfG9IUlLYz5y1CH6G/9XYbrxQLq3Z14RNvkCC6oe+OcFlyUpwUbkg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz",
+      "integrity": "sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==",
       "dev": true,
       "requires": {
+        "@typescript-eslint/types": "3.10.1",
+        "@typescript-eslint/visitor-keys": "3.10.1",
         "debug": "^4.1.1",
-        "eslint-visitor-keys": "^1.1.0",
         "glob": "^7.1.6",
         "is-glob": "^4.0.1",
         "lodash": "^4.17.15",
@@ -140,6 +159,15 @@
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz",
+      "integrity": "sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "acorn": {
@@ -588,9 +616,9 @@
       }
     },
     "eslint-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-      "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "devDependencies": {
     "@types/node": "^8.9.5",
     "@types/tape": "^4.13.0",
-    "@typescript-eslint/eslint-plugin": "^2.33.0",
-    "@typescript-eslint/parser": "^2.33.0",
+    "@typescript-eslint/eslint-plugin": "^3.10.1",
+    "@typescript-eslint/parser": "^3.10.1",
     "cross-env": "^6.0.3",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typedoc-plugin-sourcefile-url": "^1.0.4"
   },
   "dependencies": {
-    "typescript": "^3.8.2",
+    "typescript": "^3.8.2 || ^4.0.2",
     "vlq": "^1.0.0"
   },
   "prettier": {

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -49,7 +49,11 @@ export class SourceMapDecoder {
      *
      * @throws if `source` is not present in the source map
      */
-    public decode(source: string, line: number, column: number) {
+    public decode(
+        source: string,
+        line: number,
+        column: number
+    ): string | null {
         const descs = this[_functionDescs].get(source);
         // `null` entries in the source map become empty arrays in `[_functionDescs]`
         // so `descs === undefined` means `source` is not present in the source map

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -63,7 +63,6 @@ export function encode(
     const enriched = {
         ...sourceMap,
         names: names,
-        // eslint-disable-next-line @typescript-eslint/camelcase
         x_com_bloomberg_sourcesFunctionMappings: sourcesFunctionMappings,
     };
     validateEnrichedSourceMap(enriched);

--- a/src/functionDesc.ts
+++ b/src/functionDesc.ts
@@ -72,7 +72,7 @@ export function isPartialOverlap(a: FunctionDesc, b: FunctionDesc): boolean {
 /**
  * @ignore Not exported outside of package
  */
-export function compareFunction(a: FunctionDesc, b: FunctionDesc) {
+export function compareFunction(a: FunctionDesc, b: FunctionDesc): -1 | 0 | 1 {
     if (a.startLine < b.startLine) {
         return -1;
     } else if (a.startLine > b.startLine) {

--- a/tests/encoder.t.ts
+++ b/tests/encoder.t.ts
@@ -37,7 +37,6 @@ test("encoder module test: empty function descs", (t) => {
     const functionsDescs = new Map<string, FunctionDesc[]>();
     const expected = {
         ...sourceMap,
-        // eslint-disable-next-line @typescript-eslint/camelcase
         x_com_bloomberg_sourcesFunctionMappings: [null, null, null],
     };
     const actual = encode(sourceMap, functionsDescs);
@@ -51,7 +50,6 @@ test("encoder module test: empty sources", (t) => {
     let functionsDescs = new Map<string, FunctionDesc[]>();
     const expected = {
         ...sourceMap,
-        // eslint-disable-next-line @typescript-eslint/camelcase
         x_com_bloomberg_sourcesFunctionMappings: [],
     };
     let actual = encode(sourceMap, functionsDescs);

--- a/tests/helper.t.ts
+++ b/tests/helper.t.ts
@@ -17,11 +17,12 @@
 const { readFileSync }: typeof import("fs") = require("fs");
 const { join }: typeof import("path") = require("path");
 
-export function JSONFromFile(file: string, folder: string) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function JSONFromFile(file: string, folder: string): any {
     return JSON.parse(readFile(file, folder));
 }
 
-export function readFile(file: string, folder: string) {
+export function readFile(file: string, folder: string): string {
     const PATH_TO_FIXTURES = join(__dirname, "fixtures", folder);
     return readFileSync(join(PATH_TO_FIXTURES, file), "utf8");
 }


### PR DESCRIPTION
Updating to advertise supports for TypeScript `^3.8.2 || ^4.0.2`.

Updated package-lock.json to ensure tests run against 4.0.2. As a result needed to bump @typescript-eslint/* dependencies and update a couple of source lines as a result of lint rule changes.