### PR TITLE
fix(ci): ensure CI runs against Node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - "8"
   - "10"
+  - "12"
   - "lts/*"
   - "node"
 


### PR DESCRIPTION
Signed-off-by: Thomas Chetwin <tchetwin@bloomberg.net>

**Describe your changes**
- `"node"` -> 16
- `"lts/*"` -> 14
- 12 is missing

**Additional context**
We should drop 8/10 in a major release, as per #32