### PR TITLE
Bump version to 1.5.0 for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomberg/pasta-sourcemaps",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomberg/pasta-sourcemaps",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Pretty (and) Accurate Stack Trace Analysis",
   "main": "./dist/src/main.js",
   "types": "./dist/src/main.d.ts",


### PR DESCRIPTION
Release includes:
- `devDependencies` version bumps
- TypeScript dependency version bump
  - With new fixtures to validate `#methods()` support
- GitHub Actions for CI/Release

Signed-off-by: Thomas Chetwin <tchetwin@bloomberg.net>